### PR TITLE
Fix computing pair amount for cpmm deposit

### DIFF
--- a/src/cpmm/deposit.ts
+++ b/src/cpmm/deposit.ts
@@ -32,13 +32,18 @@ export const deposit = async () => {
   // computePairAmount is not necessary, addLiquidity will compute automatically,
   // just for ui display
   /*
+  const res = await raydium.cpmm.getRpcPoolInfos([poolId]);
+  const pool1Info = res[poolId];
+
   const computeRes = await raydium.cpmm.computePairAmount({
+    baseReserve: pool1Info.baseReserve,
+    quoteReserve: pool1Info.quoteReserve,
     poolInfo,
     amount: uiInputAmount,
     slippage,
     baseIn,
     epochInfo: await raydium.fetchEpochInfo()
-  })
+  });
 
   computeRes.anotherAmount.amount -> pair amount needed to add liquidity
   computeRes.anotherAmount.fee -> token2022 transfer fee, might be undefined if isn't token2022 program


### PR DESCRIPTION
-Add baseReserve and quoteReserve parameters when calling raydium.cpmm.computePairAmount function for deposit.